### PR TITLE
Expose firstTime for OwnedToken object

### DIFF
--- a/token.go
+++ b/token.go
@@ -31,9 +31,10 @@ type Token struct {
 }
 
 type OwnedToken struct {
-	Token    Token       `json:"token"`
-	Balance  NullableInt `json:"balance,string"`
-	LastTime time.Time   `json:"lastTime"`
+	Token     Token       `json:"token"`
+	Balance   NullableInt `json:"balance,string"`
+	FirstTime time.Time   `json:"firstTime"`
+	LastTime  time.Time   `json:"lastTime"`
 }
 
 type TokenMetadata struct {


### PR DESCRIPTION
The `firstTime` is not included in the `Token` when we query by call to `/v1/tokens/balances`. In order to, get the mintedAt for tezos token we need to expose this field so application can get the time properly.