### PR TITLE
Add FlexType for unmarshaling token metadata

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -8,6 +8,17 @@ import (
 	"strings"
 )
 
+// FlexInt64 is a int64 type that accepts either string or int value when Unmarshaling
+type FlexInt64 int64
+
+func (fi *FlexInt64) UnmarshalJSON(data []byte) error {
+	if data[0] != '"' {
+		return json.Unmarshal(data, (*int64)(fi))
+	}
+
+	return json.Unmarshal(bytes.Trim(data, `"`), (*int64)(fi))
+}
+
 type NullableInt int64
 
 func (t *NullableInt) UnmarshalJSON(data []byte) error {
@@ -25,10 +36,10 @@ func (t *NullableInt) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// StringBool is a type that accepts a bool can be either string or boolean
-type StringBool bool
+// FlexBool is a bool type that accepts either string or bool value when Unmarshaling
+type FlexBool bool
 
-func (b *StringBool) UnmarshalJSON(data []byte) error {
+func (b *FlexBool) UnmarshalJSON(data []byte) error {
 	var _b bool
 
 	err := json.Unmarshal(bytes.Trim(data, `"`), &_b)
@@ -36,7 +47,7 @@ func (b *StringBool) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	*b = StringBool(_b)
+	*b = FlexBool(_b)
 
 	return nil
 }

--- a/structs_test.go
+++ b/structs_test.go
@@ -1,0 +1,32 @@
+package tzkt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalFlexInt64(t *testing.T) {
+	var i FlexInt64
+
+	err := json.Unmarshal([]byte(`"123"`), &i)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(123), int64(i))
+
+	err = json.Unmarshal([]byte("1234"), &i)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1234), int64(i))
+}
+
+func TestUnmarshalFlexBool(t *testing.T) {
+	var b FlexBool
+
+	err := json.Unmarshal([]byte(`"true"`), &b)
+	assert.NoError(t, err)
+	assert.Equal(t, true, bool(b))
+
+	err = json.Unmarshal([]byte("true"), &b)
+	assert.NoError(t, err)
+	assert.Equal(t, true, bool(b))
+}

--- a/token.go
+++ b/token.go
@@ -15,7 +15,7 @@ type FormatDimensions struct {
 type FileFormat struct {
 	URI        string           `json:"uri"`
 	FileName   string           `json:"fileName,omitempty"`
-	FileSize   int              `json:"fileSize,string"`
+	FileSize   FlexInt64        `json:"fileSize,string"`
 	MIMEType   MIMEFormat       `json:"mimeType"`
 	Dimensions FormatDimensions `json:"dimensions,omitempty"`
 }
@@ -43,7 +43,7 @@ type TokenMetadata struct {
 	RightURI        string       `json:"rightUri"`
 	ArtifactURI     string       `json:"artifactUri"`
 	DisplayURI      string       `json:"displayUri"`
-	IsBooleanAmount StringBool   `json:"isBooleanAmount"`
+	IsBooleanAmount FlexBool     `json:"isBooleanAmount"`
 	ThumbnailURI    string       `json:"thumbnailUri"`
 	Publishers      []string     `json:"publishers"`
 	Minter          string       `json:"minter"`


### PR DESCRIPTION
Since token metadata comes from the blockchain does not have a unified type (mainly because of the data come from dynamic languages), we need to add a more flexible type when unmarshaling.

Changes

- Add a new type `FlexInt64` which accept both string type and int type of integer
- Rename `StringBool` to `FlexBool`
- Add test cases